### PR TITLE
How to add p2p dependencies in a nuget package when using dotnet pack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,4 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+.DS_Store

--- a/source/DotNetLibrary.sln
+++ b/source/DotNetLibrary.sln
@@ -1,4 +1,4 @@
-
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.30114.105
@@ -6,6 +6,8 @@ MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SomeClassLib", "SomeClassLib\SomeClassLib.csproj", "{E814C871-3DE3-401C-8181-0655FB933938}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SomeClassLib.Tests", "SomeClassLib.Tests\SomeClassLib.Tests.csproj", "{5DBA7F8C-9688-40CA-A3AD-7028B65FC30E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SomePeerDependency", "SomePeerDependency\SomePeerDependency.csproj", "{7BB23A40-B696-42A8-9610-35A1076182AA}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -24,5 +26,9 @@ Global
 		{5DBA7F8C-9688-40CA-A3AD-7028B65FC30E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5DBA7F8C-9688-40CA-A3AD-7028B65FC30E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5DBA7F8C-9688-40CA-A3AD-7028B65FC30E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7BB23A40-B696-42A8-9610-35A1076182AA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7BB23A40-B696-42A8-9610-35A1076182AA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7BB23A40-B696-42A8-9610-35A1076182AA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7BB23A40-B696-42A8-9610-35A1076182AA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/source/SomeClassLib.Tests/UnitTest1.cs
+++ b/source/SomeClassLib.Tests/UnitTest1.cs
@@ -5,6 +5,6 @@ public class UnitTest1
     [Fact]
     public void Test1()
     {
-        Assert.Equal("Hello, John", Class1.Greet("John"));
+        Assert.Equal("Hello, JOHN", Class1.Greet("John"));
     }
 }

--- a/source/SomeClassLib/Class1.cs
+++ b/source/SomeClassLib/Class1.cs
@@ -1,9 +1,11 @@
-﻿namespace SomeClassLib;
+﻿using SomePeerDependency;
+
+namespace SomeClassLib;
 
 public class Class1
 {
     public static string Greet(string name)
     {
-        return $"Hello, {name}";
+        return $"Hello, {PeerClass.Upper(name)}";
     }
 }

--- a/source/SomeClassLib/SomeClassLib.csproj
+++ b/source/SomeClassLib/SomeClassLib.csproj
@@ -37,4 +37,8 @@
     <None Include="../../README.md" Pack="true" PackagePath="" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\SomePeerDependency\SomePeerDependency.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/source/SomeClassLib/SomeClassLib.csproj
+++ b/source/SomeClassLib/SomeClassLib.csproj
@@ -38,7 +38,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\SomePeerDependency\SomePeerDependency.csproj" />
+    <ProjectReference Include="..\SomePeerDependency\SomePeerDependency.csproj" PrivateAssets="All" />
   </ItemGroup>
+
+  <PropertyGroup>
+    <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);IncludeP2PAssets</TargetsForTfmSpecificBuildOutput>
+  </PropertyGroup>
+  <Target Name="IncludeP2PAssets">
+    <ItemGroup>
+        <BuildOutputInPackage Include="$(OutputPath)SomePeerDependency.dll" />
+    </ItemGroup>
+</Target>
 
 </Project>

--- a/source/SomePeerDependency/PeerClass.cs
+++ b/source/SomePeerDependency/PeerClass.cs
@@ -1,0 +1,8 @@
+namespace SomePeerDependency;
+public class PeerClass
+{
+    public static string Upper(string text)
+    {
+        return text.ToUpper();
+    }
+}

--- a/source/SomePeerDependency/SomePeerDependency.csproj
+++ b/source/SomePeerDependency/SomePeerDependency.csproj
@@ -5,6 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
 </Project>

--- a/source/SomePeerDependency/SomePeerDependency.csproj
+++ b/source/SomePeerDependency/SomePeerDependency.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
nuget.exe has a switch to solve this common use case [`-IncludeReferencedProjects`](https://docs.microsoft.com/en-us/nuget/reference/cli-reference/cli-ref-pack), but `dotnet pack` does not. 

- https://github.com/dotnet/sdk/issues/6688#issuecomment-333318028
- https://github.com/NuGet/Home/issues/3891

With this change, the nuget contents will be:

```
Contents:
  - File:    _rels/.rels
  - File:    [Content_Types].xml
  - File:    icon.512x512.png
  - File:    lib/net5.0/SomeClassLib.dll
  - File:    lib/net5.0/SomePeerDependency.dll 👈
  - File:    lib/net6.0/SomeClassLib.dll
  - File:    lib/net6.0/SomePeerDependency.dll 👈
  - File:    package/services/metadata/core-properties/f9524ad71fec4ad3bed3d935dd3671f3.psmdcp
  - File:    README.md
  - File:    SomeClassLib.nuspec
```