### PR TITLE
Use GitHub CLI for GitHub Releases with release notes

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -29,24 +29,9 @@ jobs:
         run: dotnet pack source /p:Version=${{ steps.gitversion.outputs.majorMinorPatch }} /p:InformationalVersion=${{ steps.gitversion.outputs.informationalVersion }} /p:PackageReleaseNotes="https://github.com/$GITHUB_REPOSITORY/releases/tag/${{ steps.gitversion.outputs.majorMinorPatch }}" -o ./releases
       - name: Publish
         run: dotnet nuget push ./releases/**/*.nupkg -k=${{ secrets.NUGETORGAPIKEY }} -s=nuget.org
-      - name: Generate CHANGELOG.md
-        id: releasenotes
-        run: |
-          gh api repos/$GITHUB_REPOSITORY/releases/generate-notes \
-          -f tag_name="${{ steps.gitversion.outputs.majorMinorPatch }}" \
-          -q .body > CHANGELOG.md
-          echo -e "\n\n" >> CHANGELOG.md
-          git log $(git describe --tags --abbrev=0)..HEAD --oneline >> CHANGELOG.md
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
+        continue-on-error: true
+        run: gh release create ${{ steps.gitversion.outputs.majorMinorPatch }} --generate-notes
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ steps.gitversion.outputs.majorMinorPatch }}
-          release_name: Release ${{ steps.gitversion.outputs.majorMinorPatch }}
-          body_path: CHANGELOG.md
-          draft: false
-          prerelease: false
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
`actions/create-release@v1` [is deprecated](https://github.com/actions/create-release/issues/119), and the GitHub CLI now supports [automatically generating notes when creating the release](https://cli.github.com/manual/gh_release_create).